### PR TITLE
PRKT-70 Laser Frame ID Cannot Be Configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - In-Development
+### Added
+- Allow modification of laser scan frame id
+
 ## [1.0.1] - 2021-06-21
 ### Changed
 - Support Parakeet SDK versions beyond 1.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.10)
-project(parakeet_ros VERSION 1.0.1)
+project(parakeet_ros VERSION 1.0.2)
 
 ## Find catkin and any catkin packages
 find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs genmsg sensor_msgs)

--- a/Launch/Example.launch
+++ b/Launch/Example.launch
@@ -9,5 +9,8 @@
 
 		<!-- Optional, default is "scan" -->
 		<param name="laserScanTopic" value="scan" />
+
+		<!-- Optional, default is "laser" -->
+		<param name="laserScanFrameID" value="laser" />
 	</node>
 </launch>

--- a/docs/Connecting via RViz.md
+++ b/docs/Connecting via RViz.md
@@ -8,7 +8,7 @@ rviz
 ```
 
 #### 3. Connecting to parakeet_ros node
-- Inside rviz, under Displays -> Global Options, set Fixed Frame to "laser"
+- Inside rviz, under Displays -> Global Options, set Fixed Frame to the value of the parameter: laserScanFrameID, defaults to: laser
 - Near the bottom left of rviz, click Add
 - Select LaserScan and click OK
 - Open the LaserScan tree under the Displays section

--- a/docs/Runtime Parameters.md
+++ b/docs/Runtime Parameters.md
@@ -85,3 +85,10 @@ The topic the laser scan should be published under
 ie: "myCustomTopic"
 
 default value: "scan"
+
+#### laserScanFrameID - OPTIONAL
+The frame ID the laser scan should be published under
+
+ie: "myCustomFrameID"
+
+default value: "laser"

--- a/src/ROSNode.cpp
+++ b/src/ROSNode.cpp
@@ -30,6 +30,7 @@ if(!nodeHandle.getParam(#param, param) && !optional)           \
 ros::Publisher rosNodePublisher;
 ros::Publisher debugMessagePublisher;
 uint32_t sequenceID = 0;
+std::string laserScanFrameID;
 
 void onPointsReceived(const mechaspin::parakeet::ScanDataPolar& scanData)
 {
@@ -48,7 +49,7 @@ void onPointsReceived(const mechaspin::parakeet::ScanDataPolar& scanData)
     int nanoSec = std::chrono::duration_cast<std::chrono::nanoseconds>(timeSinceEpoch).count();
     msg.header.stamp = ros::Time(sec, nanoSec);
 
-    msg.header.frame_id = "laser";
+    msg.header.frame_id = laserScanFrameID;
 
     float minAngle_rad = 2*M_PI;
     float maxAngle_rad = -2*M_PI;
@@ -91,6 +92,8 @@ int main(int argc, char **argv)
 
     std::string laserScanTopic;
     GET_PARAM(laserScanTopic, true);
+    GET_PARAM(laserScanFrameID, true);
+    laserScanFrameID = laserScanFrameID == "" ? "laser" : laserScanFrameID;
 
     rosNodePublisher = nodeHandle.advertise<sensor_msgs::LaserScan>(laserScanTopic == ""?"scan":laserScanTopic, 1000);
     debugMessagePublisher = nodeHandle.advertise<std_msgs::String>("debug_msgs", 1000);


### PR DESCRIPTION
Allow modification of laser scan frame ID via a rosparam.