### PR TITLE
PRKT-67 Catkinize_SDK_To_Be_Build_Inside_ROS_Workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 build/
-
 .vscode/
+parakeet-sdk/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.2] - In-Development
+## [1.1.0] - In-Development
 ### Added
 - Allow modification of laser scan frame id
 ### Modified
 - Changed the ROS LaserScan message fields to contain the proper information
+- Changed how the Parakeet-SDK project should be installed for the ROS node to be aware of it
 
 ## [1.0.1] - 2021-06-21
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,24 @@
 cmake_minimum_required (VERSION 3.10)
-project(parakeet_ros VERSION 1.0.2)
+project(parakeet_ros VERSION 1.1.0)
 
 ## Find catkin and any catkin packages
 find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs genmsg sensor_msgs)
 
 ## Import Parakeet SDK
-find_package(Parakeet REQUIRED)
+if(FIND_PKG_PARAKEET_SDK)
+	find_package(Parakeet REQUIRED)
+	set(PARAKEET_TARGET_NAME Parakeet::Parakeet)
+else()
+	add_subdirectory(parakeet-sdk)
+	set(PARAKEET_TARGET_NAME Parakeet)
+endif()
 
 ## Declare a catkin package
 catkin_package()
 
 ## Include directories
-include_directories(include ${catkin_INCLUDE_DIRS} Parakeet::Parakeet)
+include_directories(include ${catkin_INCLUDE_DIRS} ${PARAKEET_TARGET_NAME})
 
 ## Build package
 add_executable(parakeet_ros_talker src/ROSNode.cpp)
-target_link_libraries(parakeet_ros_talker ${catkin_LIBRARIES} Parakeet::Parakeet)
+target_link_libraries(parakeet_ros_talker ${catkin_LIBRARIES} ${PARAKEET_TARGET_NAME})

--- a/docs/Building and Running.md
+++ b/docs/Building and Running.md
@@ -1,12 +1,15 @@
 # Parakeet ROS Node Building and Running using Terminal
-#### 1. Install the parakeet-sdk following the [Building and Installing](https://github.com/MechaSpin/parakeet-sdk/blob/main/docs/Building%20and%Installing.md) instructions
-#### 2. Clone parakeet-ros into your catkin workspace folder (~/catkin_ws), the cloned directory will be refered to as {PARAKEET_ROS_ROOT}
-
+#### 1. Install [ROS](http://wiki.ros.org/ROS/Installation)
+#### 2. Clone parakeet-ros into your catkin workspace source folder (~/catkin_ws/src), the cloned directory will be refered to as {PARAKEET_ROS_ROOT}
 ```
 git clone https://github.com/MechaSpin/parakeet-ros
 ```
 
-#### 3. Install [ROS](http://wiki.ros.org/ROS/Installation)
+#### 3. Clone parakeet-sdk into the parakeet-ros folder
+```
+cd {PARAKEET_ROS_ROOT}
+git clone https://github.com/MechaSpin/parakeet-sdk
+```
 #### 4. Building via Terminal
 - Navigate to your catkin workspace folder 
 


### PR DESCRIPTION
Building the ROS node for a user should all be able to be done through catkin. This change allows the user to do so by having them clone the parakeet-sdk as a subdirectory of the parakeet-ros project. An option in the CMake file exists to also support a installed copy of parakeet-sdk, as previously used.