### PR TITLE
PRKT-71 Published Topics are in Private Namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - In-Development
+## [2.0.0] - In-Development
 ### Added
 - Allow modification of laser scan frame id
 - Now installable via catkin_make install
 ### Modified
 - Changed the ROS LaserScan message fields to contain the proper information
 - Changed how the Parakeet-SDK project should be installed for the ROS node to be aware of it
+- Moved published topics and parameters to under the global ROS namespace
 
 ## [1.0.1] - 2021-06-21
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.10)
-project(parakeet_ros VERSION 1.1.0)
+project(parakeet_ros VERSION 2.0.0)
 
 ## Find catkin and any catkin packages
 find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs genmsg sensor_msgs)

--- a/Launch/Example.launch
+++ b/Launch/Example.launch
@@ -1,16 +1,16 @@
 <launch>
-	<node pkg="parakeet_ros" name="parakeet_ros_talker" type="parakeet_ros_talker">
-		<param name="port" value="/dev/ttyUSB0" />
-		<param name="baudrate" value="0" />
-		<param name="intensityData" value="true" />
-		<param name="scanningFrequency_Hz" value="10" />
-		<param name="dataSmoothing" value="false" />
-		<param name="dragPointRemoval" value="false" />
+	<param name="port" value="/dev/ttyUSB0" />
+	<param name="baudrate" value="0" />
+	<param name="intensityData" value="true" />
+	<param name="scanningFrequency_Hz" value="10" />
+	<param name="dataSmoothing" value="false" />
+	<param name="dragPointRemoval" value="false" />
 
-		<!-- Optional, default is "scan" -->
-		<param name="laserScanTopic" value="scan" />
+	<!-- Optional, default is "scan" -->
+	<param name="laserScanTopic" value="scan" />
 
-		<!-- Optional, default is "laser" -->
-		<param name="laserScanFrameID" value="laser" />
-	</node>
+	<!-- Optional, default is "laser" -->
+	<param name="laserScanFrameID" value="laser" />
+
+	<node pkg="parakeet_ros" type="parakeet_ros_talker" name="parakeet_ros_talker_name" />
 </launch>

--- a/docs/Runtime Parameters.md
+++ b/docs/Runtime Parameters.md
@@ -15,36 +15,19 @@ rosparam allows for parameters to be set before calling rosrun
 - For each parameter needing change, we will execute the following (subbing values in for PARAMETER and PARAMETER_VALUE)
 
 ```
-rosparam set parakeet_ros_talker/PARAMETER PARAMETER_VALUE
+rosparam set PARAMETER PARAMETER_VALUE
 ```
 
 - ie:
 
 ```
-rosparam set parakeet_ros_talker/port "/dev/ttyUSB0"
+rosparam set port "/dev/ttyUSB0"
 ```
 
 After setting the parameters, you can execute the ROS node via:
 
 
 	rosrun parakeet_ros parakeet_ros_talker
-
-
-
-#### 1c. Setting parameters during rosrun
-rosrun can also take parameters and will pass them all to rosparam
-- An execution of rosrun with setting parameters will look like:
-
-```
-rosrun parakeet_ros parakeet_ros_talker _PARAMETER1:=PARAMETER1_VALUE _PARAMETER2:=PARAMETER2_VALUE
-```
-
-- A full rosrun execution modifying each parameter will look like:
-
-```
-rosrun parakeet_ros parakeet_ros_talker _port:="/dev/ttyUSB0" _baudrate:=0 _intensityData:=true _scanningFrequency_Hz:=10 _dataSmoothing:=false _dragPointRemoval:=false
-```
-
 
 #  All parameters
 #### port

--- a/src/ROSNode.cpp
+++ b/src/ROSNode.cpp
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
     ros::init(argc, argv, NODE_NAME);
     timeReceivedLastPoints = std::chrono::system_clock::now().time_since_epoch();
 
-    ros::NodeHandle nodeHandle("~");
+    ros::NodeHandle nodeHandle("");
 
     std::string laserScanTopic;
     GET_PARAM(laserScanTopic, true);
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
     laserScanFrameID = laserScanFrameID == "" ? "laser" : laserScanFrameID;
 
     rosNodePublisher = nodeHandle.advertise<sensor_msgs::LaserScan>(laserScanTopic == ""?"scan":laserScanTopic, 1000);
-    debugMessagePublisher = nodeHandle.advertise<std_msgs::String>("debug_msgs", 1000);
+    debugMessagePublisher = nodeHandle.advertise<std_msgs::String>("parakeet_ros_debug_messages", 1000);
 
     //Get params from paremeter server
     // ex: rosrun parakeet_ros parakeet_ros_talker _port:="/dev/ttyUSB0" _baudrate:=500000 _intensityData:=true _scanningFrequency_Hz:=10 _dataSmoothing:=false _dragPointRemoval:=false


### PR DESCRIPTION
Published topics are now under the global scope. Below is a demonstration of the change.

```
{NODE_NAME}/debugMsgs            ->   /parakeet_ros_debug_messages
{NODE_NAME}/{LASER_SCAN_TOPIC}   ->   /{LASER_SCAN_TOPIC}
```
The same applies to parameters:
```
{NODE_NAME}/port                 ->   /port
{NODE_NAME}/intensityData        ->   /intensityData
```

This has the unfortunate downside that parameters which differ between runs need to be re-specified every time. 