### PR TITLE
PRKT-84 SDK-Dependent projects using older versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the ROS LaserScan message fields to contain the proper information
 - Changed how the Parakeet-SDK project should be installed for the ROS node to be aware of it
 - Moved published topics and parameters to under the global ROS namespace
+- Modified CMake, when using find_package, to find the latest version of parakeet-sdk which can be found
 
 ## [1.0.1] - 2021-06-21
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs genmsg sensor_msgs
 
 ## Import Parakeet SDK
 if(FIND_PKG_PARAKEET_SDK)
+	set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
+	set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
 	find_package(Parakeet REQUIRED)
 	set(PARAKEET_TARGET_NAME Parakeet::Parakeet)
 else()


### PR DESCRIPTION
Modified CMake, when using find_package, to find the latest version of parakeet-sdk which can be found