### PR TITLE
2.0.0 Release

### DIFF
--- a/.github/workflows/add_copyright_information.yaml
+++ b/.github/workflows/add_copyright_information.yaml
@@ -1,30 +1,30 @@
-name: Add Copyright Information Action
+name: Run Copyright Information Action
+
 on: [push]
+
+env:
+  DEVTOOLS_REPO: MechaSpin/parakeet-devtools
+  DEVTOOLS_REPO_BRANCH: main
+  PERSONAL_ACCESS_TOKEN: ${{ secrets.DEVTOOLS_ACCESS_TOKEN }}
+
 jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-        with:
-         path: parakeet
-      - name: Clone python script repo
-        uses: actions/checkout@v2
-        with:
-         repository: 'MechaSpin/parakeet-devtools'
-         path: 'parakeet-devtools'
-         token: ${{ secrets.DEVTOOLS_ACCESS_TOKEN }}
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: execute copyright python script
-        run: |
-          python ./parakeet-devtools/parakeet_copyright.py
-      - name: Push changes to git
-        run: |
-          cd parakeet/
-          git config --global user.name 'CopyrightGitHubAction'
-          git config --global user.email 'build@mechaspin.com'
-          git commit -am "Add Copyright Information" || exit 0
-          git push
+          python-version: '3.x'
+      - name: Clone active repository/branch
+        uses: actions/checkout@v2
+        with:
+         path: parakeet
+      - name: Clone devtools repository
+        uses: actions/checkout@v2
+        with:
+         repository: ${{ env.DEVTOOLS_REPO }}
+         ref: ${{ env.DEVTOOLS_REPO_BRANCH }}
+         path: 'parakeet-devtools'
+         token: ${{ env.PERSONAL_ACCESS_TOKEN }}
+      - name: Run Copyright Action
+        uses: ./parakeet-devtools/actions/copyright_action/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 build/
-
 .vscode/
+parakeet-sdk/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - In-Development
+## [2.0.0] - In-Development
 ### Added
 - Allow modification of laser scan frame id
 - Now installable via catkin_make install
 ### Modified
 - Changed the ROS LaserScan message fields to contain the proper information
 - Changed how the Parakeet-SDK project should be installed for the ROS node to be aware of it
+- Moved published topics and parameters to under the global ROS namespace
 
 ## [1.0.1] - 2021-06-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2021-06-21
+### Changed
+- Support Parakeet SDK versions beyond 1.0.0
+- Properly label units of measure on variables
+
 ## [1.0.0] - 2021-06-07
 ### Added
 - Publication of LaserScan data to a ROS topic from a Parakeet Pro, using the parakeet-sdk 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Now installable via catkin_make install
 ### Modified
 - Changed the ROS LaserScan message fields to contain the proper information
-- Changed how the Parakeet-SDK project should be installed for the ROS node to be aware of it
+- [BREAKING] Changed how the Parakeet-SDK project should be installed for the ROS node to be aware of it
 - Moved published topics and parameters to under the global ROS namespace
 - Modified CMake, when using find_package, to find the latest version of parakeet-sdk which can be found
 - Updated copyright action to call the action from inside the parakeet-devtools repo
+- Bumped to parakeet-sdk v2.0.0
 
 ## [1.0.1] - 2021-06-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - In-Development
+## [2.0.0] - 2021-07-12
 ### Added
 - Allow modification of laser scan frame id
 - Now installable via catkin_make install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - In-Development
 ### Added
 - Allow modification of laser scan frame id
+- Now installable via catkin_make install
 ### Modified
 - Changed the ROS LaserScan message fields to contain the proper information
 - Changed how the Parakeet-SDK project should be installed for the ROS node to be aware of it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed how the Parakeet-SDK project should be installed for the ROS node to be aware of it
 - Moved published topics and parameters to under the global ROS namespace
 - Modified CMake, when using find_package, to find the latest version of parakeet-sdk which can be found
+- Updated copyright action to call the action from inside the parakeet-devtools repo
 
 ## [1.0.1] - 2021-06-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.2] - In-Development
+## [1.1.0] - In-Development
 ### Added
 - Allow modification of laser scan frame id
 ### Modified
 - Changed the ROS LaserScan message fields to contain the proper information
+- Changed how the Parakeet-SDK project should be installed for the ROS node to be aware of it
 
 ## [1.0.1] - 2021-06-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.2] - In-Development
 ### Added
 - Allow modification of laser scan frame id
+### Modified
+- Changed the ROS LaserScan message fields to contain the proper information
 
 ## [1.0.1] - 2021-06-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the ROS LaserScan message fields to contain the proper information
 - Changed how the Parakeet-SDK project should be installed for the ROS node to be aware of it
 - Moved published topics and parameters to under the global ROS namespace
+- Modified CMake, when using find_package, to find the latest version of parakeet-sdk which can be found
 
 ## [1.0.1] - 2021-06-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - In-Development
+### Added
+- Allow modification of laser scan frame id
+
 ## [1.0.1] - 2021-06-21
 ### Changed
 - Support Parakeet SDK versions beyond 1.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.10)
 project(parakeet_ros VERSION 2.0.0)
 
 ## Find catkin and any catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs genmsg sensor_msgs)
+find_package(catkin REQUIRED COMPONENTS roscpp std_msgs sensor_msgs)
 
 ## Import Parakeet SDK
 if(FIND_PKG_PARAKEET_SDK)
@@ -22,10 +22,16 @@ catkin_package()
 include_directories(include ${catkin_INCLUDE_DIRS} ${PARAKEET_TARGET_NAME})
 
 ## Build package
-add_executable(parakeet_ros_talker src/ROSNode.cpp)
+add_executable(parakeet_ros_talker src/main.cpp src/ROSNode.cpp include/ROSNode.h)
 target_link_libraries(parakeet_ros_talker ${catkin_LIBRARIES} ${PARAKEET_TARGET_NAME})
 
-install( TARGETS
+## Install
+install(TARGETS
     parakeet_ros_talker
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY 
+  include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.10)
-project(parakeet_ros VERSION 1.1.0)
+project(parakeet_ros VERSION 2.0.0)
 
 ## Find catkin and any catkin packages
 find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs genmsg sensor_msgs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,21 +9,19 @@ if(FIND_PKG_PARAKEET_SDK)
 	set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
 	set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
 	find_package(Parakeet REQUIRED)
-	set(PARAKEET_TARGET_NAME Parakeet::Parakeet)
 else()
 	add_subdirectory(parakeet-sdk)
-	set(PARAKEET_TARGET_NAME Parakeet)
 endif()
 
 ## Declare a catkin package
 catkin_package()
 
 ## Include directories
-include_directories(include ${catkin_INCLUDE_DIRS} ${PARAKEET_TARGET_NAME})
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 ## Build package
 add_executable(parakeet_ros_talker src/main.cpp src/ROSNode.cpp include/ROSNode.h)
-target_link_libraries(parakeet_ros_talker ${catkin_LIBRARIES} ${PARAKEET_TARGET_NAME})
+target_link_libraries(parakeet_ros_talker ${catkin_LIBRARIES} Parakeet::Parakeet)
 
 ## Install
 install(TARGETS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,8 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${PARAKEET_TARGET_NAME})
 ## Build package
 add_executable(parakeet_ros_talker src/ROSNode.cpp)
 target_link_libraries(parakeet_ros_talker ${catkin_LIBRARIES} ${PARAKEET_TARGET_NAME})
+
+install( TARGETS
+    parakeet_ros_talker
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,24 @@
 cmake_minimum_required (VERSION 3.10)
-project(parakeet_ros VERSION 1.0.2)
+project(parakeet_ros VERSION 1.1.0)
 
 ## Find catkin and any catkin packages
 find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs genmsg sensor_msgs)
 
 ## Import Parakeet SDK
-find_package(Parakeet REQUIRED)
+if(FIND_PKG_PARAKEET_SDK)
+	find_package(Parakeet REQUIRED)
+	set(PARAKEET_TARGET_NAME Parakeet::Parakeet)
+else()
+	add_subdirectory(parakeet-sdk)
+	set(PARAKEET_TARGET_NAME Parakeet)
+endif()
 
 ## Declare a catkin package
 catkin_package()
 
 ## Include directories
-include_directories(include ${catkin_INCLUDE_DIRS} Parakeet::Parakeet)
+include_directories(include ${catkin_INCLUDE_DIRS} ${PARAKEET_TARGET_NAME})
 
 ## Build package
 add_executable(parakeet_ros_talker src/ROSNode.cpp)
-target_link_libraries(parakeet_ros_talker ${catkin_LIBRARIES} Parakeet::Parakeet)
+target_link_libraries(parakeet_ros_talker ${catkin_LIBRARIES} ${PARAKEET_TARGET_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.10)
-project(parakeet_ros VERSION 1.0.1)
+project(parakeet_ros VERSION 1.0.2)
 
 ## Find catkin and any catkin packages
 find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs genmsg sensor_msgs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs genmsg sensor_msgs
 
 ## Import Parakeet SDK
 if(FIND_PKG_PARAKEET_SDK)
+	set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
+	set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
 	find_package(Parakeet REQUIRED)
 	set(PARAKEET_TARGET_NAME Parakeet::Parakeet)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,11 @@
 cmake_minimum_required (VERSION 3.10)
-project(parakeet_ros VERSION 1.0.0)
+project(parakeet_ros VERSION 1.0.1)
 
 ## Find catkin and any catkin packages
 find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs genmsg sensor_msgs)
 
-## Generate added messages and services
-generate_messages(DEPENDENCIES std_msgs)
-
 ## Import Parakeet SDK
-find_package(Parakeet 1.0.0 REQUIRED)
+find_package(Parakeet REQUIRED)
 
 ## Declare a catkin package
 catkin_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.5)
 project(parakeet_ros VERSION 2.0.0)
 
 ## Find catkin and any catkin packages

--- a/Launch/Example.launch
+++ b/Launch/Example.launch
@@ -1,16 +1,16 @@
 <launch>
-	<node pkg="parakeet_ros" name="parakeet_ros_talker" type="parakeet_ros_talker">
-		<param name="port" value="/dev/ttyUSB0" />
-		<param name="baudrate" value="0" />
-		<param name="intensityData" value="true" />
-		<param name="scanningFrequency_Hz" value="10" />
-		<param name="dataSmoothing" value="false" />
-		<param name="dragPointRemoval" value="false" />
+	<param name="port" value="/dev/ttyUSB0" />
+	<param name="baudrate" value="0" />
+	<param name="intensityData" value="true" />
+	<param name="scanningFrequency_Hz" value="10" />
+	<param name="dataSmoothing" value="false" />
+	<param name="dragPointRemoval" value="false" />
 
-		<!-- Optional, default is "scan" -->
-		<param name="laserScanTopic" value="scan" />
+	<!-- Optional, default is "scan" -->
+	<param name="laserScanTopic" value="scan" />
 
-		<!-- Optional, default is "laser" -->
-		<param name="laserScanFrameID" value="laser" />
-	</node>
+	<!-- Optional, default is "laser" -->
+	<param name="laserScanFrameID" value="laser" />
+
+	<node pkg="parakeet_ros" type="parakeet_ros_talker" name="parakeet_ros_talker_name" />
 </launch>

--- a/Launch/Example.launch
+++ b/Launch/Example.launch
@@ -9,5 +9,8 @@
 
 		<!-- Optional, default is "scan" -->
 		<param name="laserScanTopic" value="scan" />
+
+		<!-- Optional, default is "laser" -->
+		<param name="laserScanFrameID" value="laser" />
 	</node>
 </launch>

--- a/docs/Building and Running.md
+++ b/docs/Building and Running.md
@@ -1,12 +1,15 @@
 # Parakeet ROS Node Building and Running using Terminal
-#### 1. Install the parakeet-sdk following the [Building and Installing](https://github.com/MechaSpin/parakeet-sdk/blob/main/docs/Building%20and%Installing.md) instructions
-#### 2. Clone parakeet-ros into your catkin workspace folder (~/catkin_ws), the cloned directory will be refered to as {PARAKEET_ROS_ROOT}
-
+#### 1. Install [ROS](http://wiki.ros.org/ROS/Installation)
+#### 2. Clone parakeet-ros into your catkin workspace source folder (~/catkin_ws/src), the cloned directory will be refered to as {PARAKEET_ROS_ROOT}
 ```
 git clone https://github.com/MechaSpin/parakeet-ros
 ```
 
-#### 3. Install [ROS](http://wiki.ros.org/ROS/Installation)
+#### 3. Clone parakeet-sdk into the parakeet-ros folder
+```
+cd {PARAKEET_ROS_ROOT}
+git clone https://github.com/MechaSpin/parakeet-sdk
+```
 #### 4. Building via Terminal
 - Navigate to your catkin workspace folder 
 

--- a/docs/Connecting via RViz.md
+++ b/docs/Connecting via RViz.md
@@ -14,4 +14,3 @@ rviz
 - Open the LaserScan tree under the Displays section
 - Specify the topic the ROS Node is publishing on (defaults to "/parakeet_ros_talker/scan")
 - Note: This topic can be specified through the parameter server
-- Note: If messages are being recieved, but no data is visible, consider upping the LaserScan size, and zooming out

--- a/docs/Connecting via RViz.md
+++ b/docs/Connecting via RViz.md
@@ -8,7 +8,7 @@ rviz
 ```
 
 #### 3. Connecting to parakeet_ros node
-- Inside rviz, under Displays -> Global Options, set Fixed Frame to "laser"
+- Inside rviz, under Displays -> Global Options, set Fixed Frame to the value of the parameter: laserScanFrameID, defaults to: laser
 - Near the bottom left of rviz, click Add
 - Select LaserScan and click OK
 - Open the LaserScan tree under the Displays section

--- a/docs/Runtime Parameters.md
+++ b/docs/Runtime Parameters.md
@@ -15,36 +15,19 @@ rosparam allows for parameters to be set before calling rosrun
 - For each parameter needing change, we will execute the following (subbing values in for PARAMETER and PARAMETER_VALUE)
 
 ```
-rosparam set parakeet_ros_talker/PARAMETER PARAMETER_VALUE
+rosparam set PARAMETER PARAMETER_VALUE
 ```
 
 - ie:
 
 ```
-rosparam set parakeet_ros_talker/port "/dev/ttyUSB0"
+rosparam set port "/dev/ttyUSB0"
 ```
 
 After setting the parameters, you can execute the ROS node via:
 
 
 	rosrun parakeet_ros parakeet_ros_talker
-
-
-
-#### 1c. Setting parameters during rosrun
-rosrun can also take parameters and will pass them all to rosparam
-- An execution of rosrun with setting parameters will look like:
-
-```
-rosrun parakeet_ros parakeet_ros_talker _PARAMETER1:=PARAMETER1_VALUE _PARAMETER2:=PARAMETER2_VALUE
-```
-
-- A full rosrun execution modifying each parameter will look like:
-
-```
-rosrun parakeet_ros parakeet_ros_talker _port:="/dev/ttyUSB0" _baudrate:=0 _intensityData:=true _scanningFrequency_Hz:=10 _dataSmoothing:=false _dragPointRemoval:=false
-```
-
 
 #  All parameters
 #### port

--- a/docs/Runtime Parameters.md
+++ b/docs/Runtime Parameters.md
@@ -85,3 +85,10 @@ The topic the laser scan should be published under
 ie: "myCustomTopic"
 
 default value: "scan"
+
+#### laserScanFrameID - OPTIONAL
+The frame ID the laser scan should be published under
+
+ie: "myCustomFrameID"
+
+default value: "laser"

--- a/include/ROSNode.h
+++ b/include/ROSNode.h
@@ -1,0 +1,37 @@
+/*
+	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
+*/
+
+#pragma once
+
+#include <parakeet/Driver.h>
+#include <parakeet/util.h>
+#include "ros/ros.h"
+
+namespace mechaspin
+{
+namespace parakeet
+{
+class ROSNode
+{
+public:
+    ROSNode();
+
+    void run();
+private:
+    void sendROSDebugMessage(const std::string& debugMessage);
+
+    Driver::SensorConfiguration readSensorConfigurationFromParameterServer();
+    bool isValidScanningFrequency_HzValue(int scanningFrequency_Hz);
+
+    void onPointsReceived(const mechaspin::parakeet::ScanDataPolar& scanData);
+
+    ros::Publisher rosNodePublisher;
+    ros::Publisher debugMessagePublisher;
+    uint32_t sequenceID;
+    std::string laserScanFrameID;
+    std::chrono::system_clock::duration timeReceivedLastPoints;
+    ros::NodeHandle nodeHandle;
+};
+}
+}

--- a/include/ROSNode.h
+++ b/include/ROSNode.h
@@ -2,7 +2,8 @@
 	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
 */
 
-#pragma once
+#ifndef PARAKEET_ROS_ROSNODE_H
+#define PARAKEET_ROS_ROSNODE_H
 
 #include <parakeet/Driver.h>
 #include <parakeet/util.h>
@@ -35,3 +36,5 @@ private:
 };
 }
 }
+
+#endif

--- a/src/ROSNode.cpp
+++ b/src/ROSNode.cpp
@@ -61,7 +61,7 @@ void onPointsReceived(const mechaspin::parakeet::ScanDataPolar& scanData)
     int currentTimeSinceEpochNanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(currentTimeSinceEpoch).count() - (currentTimeSinceEpochSeconds * NANOSECONDS_IN_SECOND);
     laserScanMessage.header.stamp = ros::Time(currentTimeSinceEpochSeconds, currentTimeSinceEpochNanoseconds);
 
-    laserScanMessage.header.frame_id = "laser";
+    laserScanMessage.header.frame_id = laserScanFrameID;
 
     float minAngle_rad = mechaspin::parakeet::util::degreesToRadians(scanData.getPoints()[0].getAngle_deg());
     float maxAngle_rad = mechaspin::parakeet::util::degreesToRadians(scanData.getPoints()[numberOfPointsReceived - 1].getAngle_deg());

--- a/src/ROSNode.cpp
+++ b/src/ROSNode.cpp
@@ -19,8 +19,8 @@ namespace mechaspin
 {
 namespace parakeet
 {
-    const uint32_t PARAKEET_SENSOR_MIN_RANGE_MM = 0;
-    const uint32_t PARAKEET_SENSOR_MAX_RANGE_MM = 50000;
+    const uint32_t PARAKEET_SENSOR_MIN_RANGE_M = 0;
+    const uint32_t PARAKEET_SENSOR_MAX_RANGE_M = 50;
     const double NANOSECONDS_IN_SECOND = 1000000000;
 
     ROSNode::ROSNode() : nodeHandle("")
@@ -100,8 +100,8 @@ namespace parakeet
 
         laserScanMessage.angle_min = minAngle_rad;
         laserScanMessage.angle_max = maxAngle_rad;
-        laserScanMessage.range_min = PARAKEET_SENSOR_MIN_RANGE_MM;
-        laserScanMessage.range_max = PARAKEET_SENSOR_MAX_RANGE_MM;
+        laserScanMessage.range_min = PARAKEET_SENSOR_MIN_RANGE_M;
+        laserScanMessage.range_max = PARAKEET_SENSOR_MAX_RANGE_M;
 
         for(auto point : scanData.getPoints())
         {

--- a/src/ROSNode.cpp
+++ b/src/ROSNode.cpp
@@ -30,6 +30,7 @@ if(!nodeHandle.getParam(#param, param) && !optional)           \
 ros::Publisher rosNodePublisher;
 ros::Publisher debugMessagePublisher;
 uint32_t sequenceID = 0;
+std::string laserScanFrameID;
 
 void onPointsReceived(const mechaspin::parakeet::ScanDataPolar& scanData)
 {
@@ -48,7 +49,7 @@ void onPointsReceived(const mechaspin::parakeet::ScanDataPolar& scanData)
     int nanoSec = std::chrono::duration_cast<std::chrono::nanoseconds>(timeSinceEpoch).count();
     msg.header.stamp = ros::Time(sec, nanoSec);
 
-    msg.header.frame_id = "laser";
+    msg.header.frame_id = laserScanFrameID;
 
     float minAngle_rad = 2*M_PI;
     float maxAngle_rad = -2*M_PI;
@@ -91,6 +92,8 @@ int main(int argc, char **argv)
 
     std::string laserScanTopic;
     GET_PARAM(laserScanTopic, true);
+    GET_PARAM(laserScanFrameID, true);
+    laserScanFrameID = laserScanFrameID == "" ? "laser" : laserScanFrameID;
 
     rosNodePublisher = nodeHandle.advertise<sensor_msgs::LaserScan>(laserScanTopic == ""?"scan":laserScanTopic, 1000);
     debugMessagePublisher = nodeHandle.advertise<std_msgs::String>("debug_msgs", 1000);

--- a/src/ROSNode.cpp
+++ b/src/ROSNode.cpp
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
     ros::init(argc, argv, NODE_NAME);
     timeReceivedLastPoints = std::chrono::system_clock::now().time_since_epoch();
 
-    ros::NodeHandle nodeHandle("~");
+    ros::NodeHandle nodeHandle("");
 
     std::string laserScanTopic;
     GET_PARAM(laserScanTopic, true);
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
     laserScanFrameID = laserScanFrameID == "" ? "laser" : laserScanFrameID;
 
     rosNodePublisher = nodeHandle.advertise<sensor_msgs::LaserScan>(laserScanTopic == ""?"scan":laserScanTopic, 1000);
-    debugMessagePublisher = nodeHandle.advertise<std_msgs::String>("debug_msgs", 1000);
+    debugMessagePublisher = nodeHandle.advertise<std_msgs::String>("parakeet_ros_debug_messages", 1000);
 
     //Get params from paremeter server
     // ex: rosrun parakeet_ros parakeet_ros_talker _port:="/dev/ttyUSB0" _baudrate:=500000 _intensityData:=true _scanningFrequency_Hz:=10 _dataSmoothing:=false _dragPointRemoval:=false

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,19 @@
+/*
+	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
+*/
+
+#include "ROSNode.h"
+
+#include "ros/ros.h"
+
+#include <string>
+
+const std::string PARAKEET_NODE_NAME = "parakeet_ros_talker";
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, PARAKEET_NODE_NAME);
+    mechaspin::parakeet::ROSNode rosNode;
+
+    rosNode.run();
+}


### PR DESCRIPTION
## [2.0.0]
### Added
- Allow modification of laser scan frame id
- Now installable via catkin_make install
### Modified
- Changed the ROS LaserScan message fields to contain the proper information
- [BREAKING] Changed how the Parakeet-SDK project should be installed for the ROS node to be aware of it
- Moved published topics and parameters to under the global ROS namespace
- Modified CMake, when using find_package, to find the latest version of parakeet-sdk which can be found
- Updated copyright action to call the action from inside the parakeet-devtools repo
- Bumped to parakeet-sdk v2.0.0