### PR TITLE
PRKT-121 Fix angle min/max fields

### DIFF
--- a/src/ROSNode.cpp
+++ b/src/ROSNode.cpp
@@ -121,9 +121,11 @@ namespace parakeet
 
         float minAngle_rad = util::degreesToRadians(scanData.getPoints()[0].getAngle_deg());
         float maxAngle_rad = util::degreesToRadians(scanData.getPoints()[numberOfPointsReceived - 1].getAngle_deg());
+        
+        laserScanMessage.angle_increment = -(maxAngle_rad - minAngle_rad) / (numberOfPointsReceived - 1);
 
         laserScanMessage.angle_min = minAngle_rad;
-        laserScanMessage.angle_max = maxAngle_rad;
+        laserScanMessage.angle_max = laserScanMessage.angle_increment * (numberOfPointsReceived - 1);
         laserScanMessage.range_min = PARAKEET_SENSOR_MIN_RANGE_M;
         laserScanMessage.range_max = PARAKEET_SENSOR_MAX_RANGE_M;
 
@@ -133,7 +135,6 @@ namespace parakeet
             laserScanMessage.intensities.push_back(point.getIntensity());
         }
 
-        laserScanMessage.angle_increment = -(maxAngle_rad - minAngle_rad) / numberOfPointsReceived;
 
         rosNodePublisher.publish(laserScanMessage);
 


### PR DESCRIPTION
With previously switching to a negative angle increment, the angle min/max became incorrect.

To help clarify this change, here is an example of the problem.

We receive the following data set in clock-wise form from the sensor:
- Start Angle = 0
- Angle Increment = 0.3
- Number of points = 1200
- End Angle = Start Angle + (Angle Increment * (Number of points - 1)) = 359.7

In a counter-clockwise fashion, the angle increment flips to -0.3, resulting in:
- Start Angle = 0
- Angle Increment = -0.3
- Number of points = 1200
- End Angle = Start Angle + (Angle Increment * (Number of points - 1)) = -359.7

The odd part here is that the start and end angle in a ROS LaserScan message, are referred to as angle_min and angle_max, respectively. It seems wrong that our angle_max is less than our angle_min in the second data set due to the naming scheme chosen by ROS.