### PR TITLE
PRKT-122 Latency Tuning Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Modified
 - Bump to using parakeet-sdk v3.0.0
 - [BREAKING] Added required runtime parameter 'sensorType'
+- Added optional runtime parameter 'extraLatencyDelay_ns'
 
 ## [2.0.0] - 2021-07-12
 ### Added

--- a/Launch/ParakeetPro.launch
+++ b/Launch/ParakeetPro.launch
@@ -6,6 +6,7 @@
 	<param name="scanningFrequency_Hz" value="10" />
 	<param name="dataSmoothing" value="false" />
 	<param name="dragPointRemoval" value="false" />
+	<param name="extraLatencyDelay_ns" value="0" />
 
 	<!-- Optional, default is "scan" -->
 	<param name="laserScanTopic" value="scan" />

--- a/Launch/ParakeetProE.launch
+++ b/Launch/ParakeetProE.launch
@@ -8,6 +8,7 @@
 	<param name="dataSmoothing" value="false" />
 	<param name="dragPointRemoval" value="false" />
 	<param name="resampleFilter" value="true" />
+	<param name="extraLatencyDelay_ns" value="0" />
 
 	<!-- Optional, default is "scan" -->
 	<param name="laserScanTopic" value="scan" />

--- a/docs/Runtime Parameters.md
+++ b/docs/Runtime Parameters.md
@@ -96,3 +96,8 @@ The frame ID the laser scan should be published under
 ie: "myCustomFrameID"
 
 default value: "laser"
+
+#### extraLatencyDelay_ns - OPTIONAL
+The number of nanoseconds to add ontop of the existing expected timestamp of: 1 / scanningFrequency_Hz seconds
+
+default value: 0

--- a/include/ROSNode.h
+++ b/include/ROSNode.h
@@ -8,7 +8,10 @@
 #include <parakeet/Pro/Driver.h>
 #include <parakeet/ProE/Driver.h>
 #include <parakeet/util.h>
-#include "ros/ros.h"
+
+#include <ros/ros.h>
+
+#include <chrono>
 
 namespace mechaspin
 {
@@ -33,8 +36,11 @@ private:
     ros::Publisher debugMessagePublisher;
     uint32_t sequenceID;
     std::string laserScanFrameID;
-    std::chrono::system_clock::duration timeReceivedLastPoints;
+    std::chrono::system_clock::time_point timeReceivedLastPoints;
     ros::NodeHandle nodeHandle;
+
+    int extraLatencyDelay_ns = 0;
+    int scanningFrequency_Hz;
 };
 }
 }


### PR DESCRIPTION
- Switched timestamp to be (1 / ScanningFrequency) seconds from the time of receiving the data
- Added optional runtime parameter 'extraLatencyDelay_ns' to add extra delay to each timestamp